### PR TITLE
Fix EnvFilter compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@
   anyhow = "1.0"
   lrwn_filters = { version = "4.10.0-test.1", features = ["serde"] }
   tracing = "0.1"
-  tracing-subscriber = { version = "0.3", features = ["fmt", "ansi"] }
+  tracing-subscriber = { version = "0.3", features = ["fmt", "ansi", "env-filter"] }
   signal-hook = "0.3"
   hex = "0.4"
   axum = "0.7"


### PR DESCRIPTION
## Summary
- enable the `env-filter` feature for `tracing-subscriber`

## Testing
- `cargo check` *(fails: could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6842aabc54348330a79484808e21c22b