### PR TITLE
Embed lrwn prefix matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,7 +161,6 @@ dependencies = [
  "clap",
  "handlebars",
  "hex",
- "lrwn_filters",
  "prometheus-client",
  "serde",
  "signal-hook",
@@ -469,14 +477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "lrwn_filters"
-version = "4.10.0-test.1"
+name = "matchers"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6371248685b05da95ee8d461d4eb15284bd68ddd559d638a0df8736a0a0a6f48"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "hex",
- "serde",
- "thiserror",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -684,6 +690,50 @@ checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
@@ -1018,10 +1068,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@
     "time",
   ] }
   anyhow = "1.0"
-  lrwn_filters = { version = "4.10.0-test.1", features = ["serde"] }
   tracing = "0.1"
   tracing-subscriber = { version = "0.3", features = ["fmt", "ansi", "env-filter"] }
   signal-hook = "0.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ impl Default for Multiplexer {
 pub struct Server {
     pub server: String,
     pub uplink_only: bool,
-    pub gateway_id_prefixes: Vec<lrwn_filters::EuiPrefix>,
+    pub gateway_id_prefixes: Vec<crate::eui_prefix::EuiPrefix>,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone)]

--- a/src/eui_prefix.rs
+++ b/src/eui_prefix.rs
@@ -1,0 +1,110 @@
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{de::{self, Visitor}, Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct EuiPrefix([u8; 8], u32);
+
+impl EuiPrefix {
+    pub fn new(prefix: [u8; 8], size: u32) -> Self {
+        EuiPrefix(prefix, size)
+    }
+
+    pub fn is_match(&self, eui_le: [u8; 8]) -> bool {
+        let eui = u64::from_le_bytes(eui_le);
+        let prefix = u64::from_be_bytes(self.0);
+        eui >> (64 - self.1) == prefix >> (64 - self.1)
+    }
+}
+
+impl fmt::Display for EuiPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", hex::encode(self.0), self.1)
+    }
+}
+
+impl fmt::Debug for EuiPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", hex::encode(self.0), self.1)
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseEuiPrefixError {
+    Format,
+    Size,
+    Hex(hex::FromHexError),
+}
+
+impl fmt::Display for ParseEuiPrefixError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseEuiPrefixError::Format => write!(f, "EuiPrefix must be in the form 0000000000000000/0"),
+            ParseEuiPrefixError::Size => write!(f, "EuiPrefix max prefix size is 64"),
+            ParseEuiPrefixError::Hex(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for ParseEuiPrefixError {}
+
+impl From<hex::FromHexError> for ParseEuiPrefixError {
+    fn from(e: hex::FromHexError) -> Self {
+        ParseEuiPrefixError::Hex(e)
+    }
+}
+
+impl FromStr for EuiPrefix {
+    type Err = ParseEuiPrefixError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.len() != 2 || parts[0].len() != 16 {
+            return Err(ParseEuiPrefixError::Format);
+        }
+
+        let mut mask = [0u8; 8];
+        hex::decode_to_slice(parts[0], &mut mask)?;
+        let size: u32 = parts[1].parse().map_err(|_| ParseEuiPrefixError::Format)?;
+        if size > 64 {
+            return Err(ParseEuiPrefixError::Size);
+        }
+        Ok(EuiPrefix(mask, size))
+    }
+}
+
+impl Serialize for EuiPrefix {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for EuiPrefix {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct EuiPrefixVisitor;
+
+        impl<'de> Visitor<'de> for EuiPrefixVisitor {
+            type Value = EuiPrefix;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("An EuiPrefix in the format 0000000000000000/0 is expected")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                EuiPrefix::from_str(value).map_err(|e| E::custom(format!("{}", e)))
+            }
+        }
+
+        deserializer.deserialize_str(EuiPrefixVisitor)
+    }
+}

--- a/src/forwarder.rs
+++ b/src/forwarder.rs
@@ -18,7 +18,7 @@ static SERVERS: OnceCell<RwLock<Vec<Server>>> = OnceCell::const_new();
 struct Server {
     server: String,
     uplink_only: bool,
-    gateway_id_prefixes: Vec<lrwn_filters::EuiPrefix>,
+    gateway_id_prefixes: Vec<crate::eui_prefix::EuiPrefix>,
     downlink_tx: UnboundedSender<(GatewayId, Vec<u8>)>,
     sockets: HashMap<GatewayId, ServerSocket>,
 }
@@ -277,7 +277,7 @@ async fn handle_pull_resp(
 async fn add_server(
     server: String,
     uplink_only: bool,
-    gateway_id_prefixes: Vec<lrwn_filters::EuiPrefix>,
+    gateway_id_prefixes: Vec<crate::eui_prefix::EuiPrefix>,
     downlink_tx: UnboundedSender<(GatewayId, Vec<u8>)>,
 ) -> Result<()> {
     info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod listener;
 pub mod monitoring;
 pub mod packets;
 pub mod traits;
+pub mod eui_prefix;

--- a/tests/test_filtered_server.rs
+++ b/tests/test_filtered_server.rs
@@ -6,7 +6,7 @@ use tokio::time::timeout;
 use tracing_subscriber::prelude::*;
 
 use chirpstack_packet_multiplexer::{config, forwarder, listener};
-use lrwn_filters::EuiPrefix;
+use chirpstack_packet_multiplexer::eui_prefix::EuiPrefix;
 
 #[tokio::test]
 async fn test() {


### PR DESCRIPTION
## Summary
- remove lrwn_filters dependency
- implement EuiPrefix matcher in this crate
- use new matcher in config, forwarder and tests

## Testing
- `cargo test --no-run`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68469ff9fc8483308b0ec86100a0d9dc